### PR TITLE
1.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Release](https://img.shields.io/github/release/gqylpy/funccache.svg?style=flat-square")](https://github.com/gqylpy/funccache/releases/latest)
 [![Python Versions](https://img.shields.io/pypi/pyversions/funccache)](https://pypi.org/project/funccache)
 [![License](https://img.shields.io/pypi/l/funccache)](https://github.com/gqylpy/funccache/blob/master/LICENSE)
-[![Downloads](https://pepy.tech/badge/funccache/month)](https://pepy.tech/project/funccache)
+[![Downloads](https://static.pepy.tech/badge/funccache)](https://pepy.tech/project/funccache)
 
 # funccache
 

--- a/funccache/__init__.py
+++ b/funccache/__init__.py
@@ -11,7 +11,7 @@ value of a callable object or all methods defined in a class.
     >>> def alpha():
     >>>     ...
 
-    @version: 1.5.3
+    @version: 1.5.4
     @author: 竹永康 <gqylpy@outlook.com>
     @source: https://github.com/gqylpy/funccache
 
@@ -30,14 +30,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from typing import Optional, Union, Callable
 
 
-def expiration_time(expires: int = -1):
-    """Decorator, can select the cache duration, by the parament `expires`, less
-    than or equal to 0 means immediate expiration."""
+def expires(duration: Optional[Union[int, float]] = None) -> Callable:
+    """Decorator, can specify the cache duration by the parameter `duration`,
+    less than or equal to 0 means immediate expiration, default never expires.
+    """
 
 
-def clear_cache_pool(func) -> None:
+def expiration_time(duration: Optional[Union[int, float]] = None) -> Callable:
+    warnings.warn(
+        f'will be deprecated soon, replaced to {expires}.', DeprecationWarning
+    )
+    return expires(duration)
+
+
+def clear_cache_pool(func: Callable) -> None:
     """Clear the cache pool for the specified function or object or class."""
     func.__cache_pool__.clear()
 
@@ -54,7 +63,8 @@ class _xe6_xad_x8c_xe7_x90_xaa_xe6_x80_xa1_xe7_x8e_xb2_xe8_x90_x8d_xe4_xba_x91:
 
     FuncCache.__module__       = __package__
     FuncCache.FuncCache        = FuncCache
-    FuncCache.expiration_time  = gcode.FunctionCallerExpirationTime
+    FuncCache.expires          = gcode.FunctionCallerExpires
+    FuncCache.expiration_time  = gcode.FunctionCallerExpires
     FuncCache.clear_cache_pool = gcode.clear_cache_pool
 
     sys.modules[__name__] = FuncCache


### PR DESCRIPTION
1. Improve parameter annotations.
2. The decorator `expiration_time` is about to be deprecated and replaced by `expires`
3. Adjust the naming of multiple internal methods, classes, and parameters, the new naming is more intuitive and clear.
---
1. 完善参数注解。
2. 装饰器 `expiration_time` 即将弃用，取而代之的是 `expires`。
3. 调整多个内部方法，类和参数的命名，新的命名更加直观和清晰。