### PR TITLE
2.0.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,28 +175,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright (c) 2022-2024 GQYLPY <http://gqylpy.com>. All rights reserved.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img alt="LOGO" src="http://www.gqylpy.com/static/img/favicon.ico" height="21" width="21"/>](http://www.gqylpy.com)
+[<img alt="LOGO" src="https://python.org/favicon.ico" height="21" width="21"/>](http://gqylpy.com)
 [![Release](https://img.shields.io/github/release/gqylpy/funccache.svg?style=flat-square")](https://github.com/gqylpy/funccache/releases/latest)
 [![Python Versions](https://img.shields.io/pypi/pyversions/funccache)](https://pypi.org/project/funccache)
 [![License](https://img.shields.io/pypi/l/funccache)](https://github.com/gqylpy/funccache/blob/master/LICENSE)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,4 +1,4 @@
-[<img alt="LOGO" src="http://www.gqylpy.com/static/img/favicon.ico" height="21" width="21"/>](http://www.gqylpy.com)
+[<img alt="LOGO" src="https://python.org/favicon.ico" height="21" width="21"/>](http://gqylpy.com)
 [![Release](https://img.shields.io/github/release/gqylpy/funccache.svg?style=flat-square")](https://github.com/gqylpy/funccache/releases/latest)
 [![Python Versions](https://img.shields.io/pypi/pyversions/funccache)](https://pypi.org/project/funccache)
 [![License](https://img.shields.io/pypi/l/funccache)](https://github.com/gqylpy/funccache/blob/master/LICENSE)

--- a/funccache/__init__.py
+++ b/funccache/__init__.py
@@ -11,12 +11,12 @@ value of a callable object or all methods defined in a class.
     >>> def alpha():
     >>>     ...
 
-    @version: 2.0.1
-    @author: 竹永康 <gqylpy@outlook.com>
-    @source: https://github.com/gqylpy/funccache
-
 ────────────────────────────────────────────────────────────────────────────────
 Copyright (c) 2022-2024 GQYLPY <http://gqylpy.com>. All rights reserved.
+
+    @version: 2.0.2
+    @author: 竹永康 <gqylpy@outlook.com>
+    @source: https://github.com/gqylpy/funccache
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ limitations under the License.
 from typing import Optional, Union, Callable
 
 
-def ttl(x: Optional[Union[str, int, float]] = None, /) -> Callable:
+def ttl(x: Optional[Union[int, float, str]] = None, /) -> Callable:
     """Decorator, can specify the cache time to live by the parameter `x`, less
     than or equal to 0 means immediate expiration, default never expires."""
 


### PR DESCRIPTION
1. Correct a consecutive judgment error in the code.
2. Refactor the internal method `Time2Second` to make it more concise and efficient.
3. Use `time.monotonic()` to replace `time.time()` for cache expiration checks.
4. Adjust the formatting and annotations of other minor code sections.
---
1. 修正代码中的一个连续判断错误。
2. 重构内部方法 `Time2Second` 使之更简洁和高效。
3. 使用 `time.monotonic()` 替换 `time.time()` 进行缓存过期检查。
4. 调整其它少量代码格式和注解。
