### PR TITLE
1.6.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,28 +175,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright (c) 2022, 2023 GQYLPY <http://gqylpy.com>. All rights reserved.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
-[<img alt="LOGO" src="http://www.gqylpy.com/static/img/favicon.ico" height="21" width="21"/>](http://www.gqylpy.com)
+[<img alt="LOGO" src="https://python.org/favicon.ico" height="21" width="21"/>](http://gqylpy.com)
 [![Release](https://img.shields.io/github/release/gqylpy/funccache.svg?style=flat-square")](https://github.com/gqylpy/funccache/releases/latest)
 [![Python Versions](https://img.shields.io/pypi/pyversions/funccache)](https://pypi.org/project/funccache)
 [![License](https://img.shields.io/pypi/l/funccache)](https://github.com/gqylpy/funccache/blob/master/LICENSE)
 [![Downloads](https://static.pepy.tech/badge/funccache)](https://pepy.tech/project/funccache)
 
 # funccache
+English | [中文](https://github.com/gqylpy/funccache/blob/master/README_CN.md)
 
-> 如其名，`funccache` 实现函数缓存功能，由 GQYLPY 团队研发的一个框架，可缓存某个函数或某个类中定义的所有方法的返回值。
-> 
-> > _你的程序中有一个函数会被多次调用，并且返回值不变，你会怎么做？为提高代码效率，你会先调用一次该函数并把返回值存到一个变量，之后就使用这个变量，而不是重复调用函数。是这样吗？你已经很不错了。但现在，我们要传授你一种比之更简明的方案，使用 `funccache` 模块直接缓存函数返回值。_
-> 
-> `funccache` 有两种使用方式：当做元类使用，将缓存其元类实例中定义的所有方法的返回值；当做装饰器使用，将缓存被装饰函数的返回值。
+`funccache`, as its name suggests, is a framework developed by the GQYLPY team that implements function caching. It can cache the return values of specific functions or all methods defined within a class.
+
+> _What if you have a function in your program that gets called multiple times and always returns the same value? To improve code efficiency, you might call the function once, store the return value in a variable, and then use that variable instead of repeatedly calling the function. Sound familiar? That's great! But now, we're here to introduce a more elegant solution: using the `funccache` module to directly cache function return values._
+
+`funccache` can be used in two ways: as a metaclass to cache the return values of all methods defined in its metaclass instances, or as a decorator to cache the return values of decorated functions.
 
 <kbd>pip3 install funccache</kbd>
 
-###### 缓存类中方法的返回值
+### Caching Return Values of Class Methods
 
 ```python
 import funccache
@@ -22,24 +23,30 @@ import funccache
 class Alpha(metaclass=funccache):
     ...
 ```
-此时，类 `Alpha` 中定义的所有方法以及`property`属性，在被其实例调用一次后，返回值都将被缓存，缓存在 `__cache_pool__` 属性中。此后的每次调用，只要参数不变，都是直接从 `__cache_pool__` 中取值，不会重复执行相关代码，大幅减少程序功耗并提高代码可读性。
+In this case, all methods and `property` attributes defined in the `Alpha` class will have their return values cached in the `__cache_pool__` attribute after being called once by an instance of the class. Subsequent calls, as long as the parameters remain the same, will directly retrieve values from `__cache_pool__` without re-executing the related code, significantly reducing program overhead and improving code readability.
 
-上述缓存功能默认只作用于单个实例，每个实例都有自己的 `__cache_pool__` 属性，若希望 `Alpha` 的所有实例共享同一份缓存，可启用 `__shared_instance_cache__` 属性：
+By default, this caching functionality only applies to individual instances, and each instance has its own `__cache_pool__` attribute. However, if you want all instances of `Alpha` to share the same cache, you can enable the `__shared_instance_cache__` attribute:
 ```python
 class Alpha(metaclass=funccache):
     __shared_instance_cache__ = True
 ```
-设置类属性 `__shared_instance_cache__ = True` 后，属性 `__cache_pool__` 将被创建在 `Alpha` 类中，而不是 `Alpha` 的每个实例中。
+Setting the class attribute `__shared_instance_cache__ = True` creates the `__cache_pool__` attribute in the `Alpha` class itself, rather than in each individual instance of `Alpha`.
 
-若希望某个方法或`property`不被缓存，可将其加入到 `__not_cache__` 列表中：
+The cache never expires by default, but you can set a time-to-live (TTL) for the cache using the class attribute `__ttl__`:
+```python
+class Alpha(metaclass=funccache):
+    __ttl__ = 60
+```
+
+If you want a specific method or `property` to not be cached, you can add it to the `__not_cache__` list:
 
 ```python
 class Alpha(metaclass=funccache):
     __not_cache__ = [method_obj_or_method_name, ...]
 ```
-另外，`Alpha` 的子类也拥有上述缓存功能。
+Additionally, subclasses of `Alpha` will also inherit the caching functionality.
 
-###### 缓存函数返回值
+### Caching Return Values of Functions
 
 ```python
 import funccache
@@ -48,9 +55,23 @@ import funccache
 def alpha():
     ...
 ```
-此时，函数 `alpha` 在被调用一次后，其返回值将被缓存。此后的每次调用，只要参数不变，都是直接从缓存中取值，而不会重复执行 `alpha` 函数。
+In this case, the return value of the `alpha` function will be cached after it is called once. Subsequent calls, as long as the parameters remain the same, will directly retrieve the value from the cache without re-executing the `alpha` function.
 
-装饰器的用法亦可获得单例类，只要实例化参数一致：
+The cache never expires by default, but if you want the cache to expire after a certain period, you can use `funccache.ttl`:
+```python
+@funccache.ttl(60)
+def alpha():
+    ...
+```
+
+You can even cache based on the number of calls using `funccache.count`:
+```python
+@funccache.count(3)
+def alpha():
+    ...
+```
+
+The decorator usage can also achieve singleton class behavior, as long as the instantiation parameters are consistent:
 ```python
 @funccache
 class Alpha:

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,0 +1,79 @@
+[<img alt="LOGO" src="https://python.org/favicon.ico" height="21" width="21"/>](http://gqylpy.com)
+[![Release](https://img.shields.io/github/release/gqylpy/funccache.svg?style=flat-square")](https://github.com/gqylpy/funccache/releases/latest)
+[![Python Versions](https://img.shields.io/pypi/pyversions/funccache)](https://pypi.org/project/funccache)
+[![License](https://img.shields.io/pypi/l/funccache)](https://github.com/gqylpy/funccache/blob/master/LICENSE)
+[![Downloads](https://static.pepy.tech/badge/funccache)](https://pepy.tech/project/funccache)
+
+# funccache
+[English](README.md) | 中文
+
+> 如其名，`funccache` 实现函数缓存功能，由 GQYLPY 团队研发的一个框架，可缓存某个函数或某个类中定义的所有方法的返回值。
+> 
+> > _你的程序中有一个函数会被多次调用，并且返回值不变，你会怎么做？为提高代码效率，你会先调用一次该函数并把返回值存到一个变量，之后就使用这个变量，而不是重复调用函数。是这样吗？你已经很不错了。但现在，我们要传授你一种比之更简明的方案，使用 `funccache` 模块直接缓存函数返回值。_
+> 
+> `funccache` 有两种使用方式：当做元类使用，将缓存其元类实例中定义的所有方法的返回值；当做装饰器使用，将缓存被装饰函数的返回值。
+
+<kbd>pip3 install funccache</kbd>
+
+### 缓存类中方法的返回值
+
+```python
+import funccache
+
+class Alpha(metaclass=funccache):
+    ...
+```
+此时，类 `Alpha` 中定义的所有方法以及`property`属性，在被其实例调用一次后，返回值都将被缓存，缓存在 `__cache_pool__` 属性中。此后的每次调用，只要参数不变，都是直接从 `__cache_pool__` 中取值，不会重复执行相关代码，大幅减少程序功耗并提高代码可读性。
+
+上述缓存功能默认只作用于单个实例，每个实例都有自己的 `__cache_pool__` 属性，若希望 `Alpha` 的所有实例共享同一份缓存，可启用 `__shared_instance_cache__` 属性：
+```python
+class Alpha(metaclass=funccache):
+    __shared_instance_cache__ = True
+```
+设置类属性 `__shared_instance_cache__ = True` 后，属性 `__cache_pool__` 将被创建在 `Alpha` 类中，而不是 `Alpha` 的每个实例中。
+
+缓存默认永不失效，使用类属性 `__ttl__` 可以设置缓存的有效时长：
+```python
+class Alpha(metaclass=funccache):
+    __ttl__ 60
+```
+
+若希望某个方法或`property`不被缓存，可将其加入到 `__not_cache__` 列表中：
+
+```python
+class Alpha(metaclass=funccache):
+    __not_cache__ = [method_obj_or_method_name, ...]
+```
+另外，`Alpha` 的子类也拥有上述缓存功能。
+
+### 缓存函数返回值
+
+```python
+import funccache
+
+@funccache
+def alpha():
+    ...
+```
+此时，函数 `alpha` 在被调用一次后，其返回值将被缓存。此后的每次调用，只要参数不变，都是直接从缓存中取值，而不会重复执行 `alpha` 函数。
+
+缓存默认永不失效，若希望缓存定期失效，可以使用 `funccache.ttl`：
+```python
+@funccache.ttl(60)
+def alpha():
+    ...
+```
+
+甚至可以使用 `funccache.count` 按调用次数缓存：
+```python
+@funccache.count(3)
+def alpha():
+    ...
+```
+
+装饰器的用法亦可获得单例类，只要实例化参数一致：
+```python
+@funccache
+class Alpha:
+    ...
+```

--- a/funccache/__init__.py
+++ b/funccache/__init__.py
@@ -11,12 +11,12 @@ value of a callable object or all methods defined in a class.
     >>> def alpha():
     >>>     ...
 
-    @version: 1.5.4
+────────────────────────────────────────────────────────────────────────────────
+Copyright (c) 2022-2024 GQYLPY <http://gqylpy.com>. All rights reserved.
+
+    @version: 1.6.0
     @author: 竹永康 <gqylpy@outlook.com>
     @source: https://github.com/gqylpy/funccache
-
-────────────────────────────────────────────────────────────────────────────────
-Copyright (c) 2022, 2023 GQYLPY <http://gqylpy.com>. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,17 +33,15 @@ limitations under the License.
 from typing import Optional, Union, Callable
 
 
-def expires(duration: Optional[Union[int, float]] = None) -> Callable:
-    """Decorator, can specify the cache duration by the parameter `duration`,
-    less than or equal to 0 means immediate expiration, default never expires.
-    """
+def ttl(x: Optional[Union[int, float, str]] = None) -> Callable:
+    """Decorator, can specify the cache time to live by the parameter `x`, less
+    than or equal to 0 means immediate expiration, default never expires."""
 
 
-def expiration_time(duration: Optional[Union[int, float]] = None) -> Callable:
-    warnings.warn(
-        f'will be deprecated soon, replaced to {expires}.', DeprecationWarning
-    )
-    return expires(duration)
+def count(x: Optional[int] = None) -> Callable:
+    """Decorator, cache according to the number of calls. Whenever the number of
+    calls reaches `x`, the cache will be invalidated, round by round. Less than
+    or equal to 0 means immediate expiration, default never expires."""
 
 
 def clear_cache_pool(func: Callable) -> None:
@@ -63,8 +61,8 @@ class _xe6_xad_x8c_xe7_x90_xaa_xe6_x80_xa1_xe7_x8e_xb2_xe8_x90_x8d_xe4_xba_x91:
 
     FuncCache.__module__       = __package__
     FuncCache.FuncCache        = FuncCache
-    FuncCache.expires          = gcode.FunctionCallerExpires
-    FuncCache.expiration_time  = gcode.FunctionCallerExpires
+    FuncCache.ttl              = gcode.FunctionCallerTTL
+    FuncCache.count            = gcode.FunctionCallerCount
     FuncCache.clear_cache_pool = gcode.clear_cache_pool
 
     sys.modules[__name__] = FuncCache

--- a/funccache/i funccache.py
+++ b/funccache/i funccache.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2022, 2023 GQYLPY <http://gqylpy.com>. All rights reserved.
+Copyright (c) 2022-2024 GQYLPY <http://gqylpy.com>. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,37 +13,79 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import re
+import sys
 import time
 import asyncio
 import threading
 import functools
 
-from typing import Union
+from types import MethodType, FunctionType
 
-FunctionType: type = threading.setprofile.__class__
+from typing import (
+    TypeVar, Type, Optional, Union, Dict, List, Tuple, Set, Iterable, Callable,
+    FrozenSet, Any
+)
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    TypeAlias = TypeVar("TypeAlias")
+
+MethodTypeOrName: TypeAlias = TypeVar('MethodTypeOrName', MethodType, str)
+Wrapped = WrappedClosure = TypeVar('Wrapped', bound=Callable[..., Any])
+WrappedReturn: TypeAlias = TypeVar('WrappedReturn')
+
+MethodCachePool: TypeAlias = Dict[
+    Union[Tuple[str, Tuple[Tuple[Any, ...], FrozenSet[Tuple[str, Any]]]], str],
+    Dict[str, Any]
+]
+
+FuncCachePool: TypeAlias = Dict[
+    Tuple[Tuple[Any, ...], FrozenSet[Tuple[str, Any]]],
+    Dict[str, Any]
+]
 
 
 class FuncCache(type):
-    __shared_instance_cache__ = False
-    __not_cache__ = []
+    __shared_instance_cache__: bool = False
+    __not_cache__: List[MethodTypeOrName] = []
+    __ttl__: Union[str, int, float] = float('inf')
 
-    def __new__(mcs, __name__: str, *a, **kw):
+    def __new__(
+            mcs, __name__: Union[str, Wrapped, Type[object]], *a, **kw
+    ) -> Union['FuncCache', 'FunctionCaller']:
         if isinstance(__name__, (FunctionType, type)):
             return FunctionCaller(__name__)
         return type.__new__(mcs, __name__, *a, **kw)
 
     def __init__(cls, __name__: str, __bases__: tuple, __dict__: dict):
-        __not_cache__: list = __dict__.get('__not_cache__')
+        __not_cache__: List[MethodTypeOrName] = __dict__.get('__not_cache__')
 
         if __not_cache__:
             cls.dedup(__not_cache__)
-            cls.check_and_tidy_not_cache(__not_cache__, __dict__)
+            cls.check_and_tidy_not_cache(__not_cache__)
             cls.dedup(__not_cache__)
+
+        if '__getattribute__' in __dict__:
+            raise AttributeError(
+                f'instances of "{FuncCache.__name__}" are not allowed to '
+                'define method "__getattribute__".'
+            )
 
         cls.__getattribute__ = __getattribute__(cls)
 
         if cls.__shared_instance_cache__:
-            cls.__cache_pool__ = {}
+            cls.__primary_lock__ = threading.Lock()
+            cls.__cache_pool__: MethodCachePool = {}
+
+        if isinstance(cls.__ttl__, str):
+            cls.__ttl__ = time2second(cls.__ttl__)
+        elif not isinstance(cls.__ttl__, (int, float)):
+            raise TypeError(
+                'class attribute "__ttl__" is expected to be of type int or '
+                f'float, not {cls.__ttl__!r}.'
+            )
 
         type.__init__(cls, __name__, __bases__, __dict__)
 
@@ -51,29 +93,28 @@ class FuncCache(type):
         ins: cls = type.__call__(cls, *a, **kw)
 
         if not cls.__shared_instance_cache__:
+            ins.__primary_lock__ = threading.Lock()
             ins.__cache_pool__ = {}
 
         return ins
 
-    def check_and_tidy_not_cache(cls, __not_cache__: list, __dict__: dict):
-        not_found = []
+    def check_and_tidy_not_cache(
+            cls, __not_cache__: List[MethodTypeOrName]
+    ) -> None:
+        not_found: Set[str] = set()
 
         for index, name_or_method in enumerate(__not_cache__):
             if name_or_method.__class__ is str:
                 name: str = name_or_method
-
                 for x in cls.local_instance_dict_set():
                     if name == x:
                         break
                 else:
-                    name in not_found or not_found.append(name)
+                    not_found.add(name)
                     continue
-
-                method = getattr(cls, name)
-
+                method: MethodType = getattr(cls, name)
             else:
-                method = name_or_method
-
+                method: MethodType = name_or_method
                 try:
                     name = __not_cache__[index] = method.__name__
                 except AttributeError:
@@ -83,30 +124,28 @@ class FuncCache(type):
                         name = __not_cache__[index] = method.fget.__name__
                     else:
                         name = name_or_method
-
                 for x in cls.local_instance_dict_set(v=True):
                     if method == x:
                         break
                 else:
-                    name in not_found or not_found.append(name)
+                    not_found.add(name)
                     continue
-
             if not (
                     callable(method)
                     or method.__class__ in (property, staticmethod, classmethod)
             ):
-                name in not_found or not_found.append(name)
+                not_found.add(name)
                 continue
 
         if not_found:
             x = f'{cls.__module__}.{cls.__name__}'
-            e = not_found if len(not_found) > 1 else not_found[0]
+            y = not_found if len(not_found) > 1 else not_found.pop()
             raise type(
                 'NotCacheDefineError', (Exception,), {'__module__': __package__}
-            )(f'"{__package__}" instance "{x}" has no method "{e}".')
+            )(f'"{__package__}" instance "{x}" has no method "{y}".')
 
     @staticmethod
-    def dedup(data: list):
+    def dedup(data: List[Any]) -> None:
         index = len(data) - 1
         while index > -1:
             offset = -1
@@ -118,192 +157,307 @@ class FuncCache(type):
                     offset -= 1
             index -= 1
 
-    def local_instance_dict_set(cls, baseclass=None, *, v: bool = False):
-        cur_cls: FuncCache or type = baseclass or cls
-
+    def local_instance_dict_set(
+            cls, baseclass: Optional['FuncCache'] = None, *, v: bool = False
+    ) -> Iterable[MethodTypeOrName]:
+        cur_cls: FuncCache = baseclass or cls
         if cur_cls.__class__ is FuncCache:
             yield from cur_cls.__dict__.values() if v else cur_cls.__dict__
             yield from cur_cls.local_instance_dict_set(cur_cls.__base__)
 
-    class NotCacheDefineError(Exception):
-        __module__ = __package__
-
 
 class MethodCaller:
 
-    def __new__(cls, cls_: FuncCache, sget, name: str, method):
-        if method.__class__ is property:
-            __cache_pool__: dict = sget('__cache_pool__')
+    def __new__(
+            cls,
+            cls_:   FuncCache,
+            sget:   Callable[[str], Any],
+            name:   str,
+            method: Union[MethodType, property]
+    ) -> Any:
+        if method.__class__ is not property:
+            return object.__new__(cls)
 
-            try:
-                cache: dict = __cache_pool__[name]
-            except KeyError:
-                cache = __cache_pool__[name] = {}
-                cache['__exec_lock__'] = threading.Event()
-                try:
+        __cache_pool__: MethodCachePool = sget('__cache_pool__')
+        cache: Dict[str, Any] = __cache_pool__.get(name)
+
+        if not cache:
+            with sget('__primary_lock__'):
+                if name in __cache_pool__:
+                    cache: Dict[str, Any] = __cache_pool__[name]
+                else:
+                    cache = __cache_pool__[name] = {
+                        '__secondary_lock__': threading.Lock(),
+                        '__expiration_time__': 0
+                    }
+
+        if cache['__expiration_time__'] < time.monotonic():
+            with cache['__secondary_lock__']:
+                if cache['__expiration_time__'] < time.monotonic():
                     cache['__return__'] = sget(name)
-                except Exception as e:
-                    del __cache_pool__[name]
-                    raise e from None
-                finally:
-                    cache['__exec_lock__'].set()
-            else:
-                if '__exec_lock__' in cache:
-                    cache['__exec_lock__'].wait()
-                    try:
-                        del cache['__exec_lock__']
-                    except KeyError:
-                        pass
-
-            return cache['__return__']
-
-        return object.__new__(cls)
-
-    def __init__(self, cls: FuncCache, sget, name: str, method):
-        self.__cls = cls
-        self.__sget = sget
-        self.__name__ = name
-        self.__func__ = method
-        self.__qualname__ = method.__qualname__
-
-    def __call__(self, *a, **kw):
-        __cache_pool__: dict = self.__sget('__cache_pool__')
-        key = self.__name__, a, str(kw)
-
-        try:
-            cache: dict = __cache_pool__[key]
-        except KeyError:
-            cache = __cache_pool__[key] = {}
-            cache['__exec_lock__'] = threading.Event()
-            try:
-                cache['__return__'] = self.__sget(self.__name__)(*a, **kw)
-            except Exception as e:
-                del __cache_pool__[key]
-                raise e from None
-            finally:
-                cache['__exec_lock__'].set()
-        else:
-            if '__exec_lock__' in cache:
-                cache['__exec_lock__'].wait()
-                try:
-                    del cache['__exec_lock__']
-                except KeyError:
-                    pass
+                    cache['__expiration_time__'] = \
+                        time.monotonic() + cls_.__ttl__
 
         return cache['__return__']
 
-    def __str__(self):
+    def __init__(
+            self,
+            cls:    FuncCache,
+            sget:   Callable[[str], Any],
+            name:   str,
+            method: MethodType
+    ):
+        self.__cls        = cls
+        self.__sget       = sget
+        self.__name__     = name
+        self.__func__     = method
+        self.__qualname__ = method.__qualname__
+
+    def __call__(self, *a, **kw) -> Any:
+        key = self.__name__, (a, frozenset(kw.items()))
+
+        __cache_pool__: MethodCachePool = self.__sget('__cache_pool__')
+        cache: Dict[str, Any] = __cache_pool__.get(key)
+
+        if not cache:
+            with self.__sget('__primary_lock__'):
+                if key in __cache_pool__:
+                    cache: Dict[str, Any] = __cache_pool__[key]
+                else:
+                    cache = __cache_pool__[key] = {
+                        '__secondary_lock__': threading.Lock(),
+                        '__expiration_time__': 0
+                    }
+
+        if cache['__expiration_time__'] < time.monotonic():
+            with cache['__secondary_lock__']:
+                if cache['__expiration_time__'] < time.monotonic():
+                    cache['__return__'] = self.__sget(self.__name__)(*a, **kw)
+                    cache['__expiration_time__'] = \
+                        time.monotonic() + self.__cls.__ttl__
+
+        return cache['__return__']
+
+    def __str__(self) -> str:
         return f'{MethodCaller.__name__}' \
                f'({self.__cls.__module__}.{self.__qualname__})'
 
 
 class FunctionCaller:
 
-    def __init__(self, func: FunctionType):
+    def __init__(self, func: Wrapped):
         self.__func__ = func
 
         if func.__class__ is FunctionType:
             self.__globals__ = func.__globals__
-            functools.wraps(self.__func__)(self)
-
+            functools.wraps(func)(self)
             if asyncio.iscoroutinefunction(getattr(func, '__wrapped__', func)):
-                self.__core__ = self.__core_async__
+                self.core = self.acore
 
-        self.__exec_lock__  = threading.Lock()
-        self.__cache_pool__ = {}
+        self.__primary_lock__ = threading.Lock()
+        self.__cache_pool__: FuncCachePool = {}
 
-    def __call__(self, *a, **kw):
-        return self.__core__(*a, **kw)
+    def __call__(self, *a, **kw) -> WrappedReturn:
+        return self.core(*a, **kw)
 
-    def __core__(self, *a, **kw):
-        key = a, str(kw)
-
-        self.__exec_lock__.acquire()
-        try:
-            if key not in self.__cache_pool__:
-                self.__cache_pool__[key] = self.__func__(*a, **kw)
-        finally:
-            self.__exec_lock__.release()
-
-        return self.__cache_pool__[key]
-
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.__func__)
 
-    async def __core_async__(self, *a, **kw):
-        key = a, str(kw)
+    def core(self, *a, **kw) -> WrappedReturn:
+        key = a, frozenset(kw.items())
 
-        self.__exec_lock__.acquire()
         try:
-            if key not in self.__cache_pool__:
-                self.__cache_pool__[key] = await self.__func__(*a, **kw)
-        finally:
-            self.__exec_lock__.release()
+            cache: Dict[str, Any] = self.__cache_pool__[key]
+        except KeyError:
+            with self.__primary_lock__:
+                if key in self.__cache_pool__:
+                    cache: Dict[str, Any] = self.__cache_pool__[key]
+                else:
+                    cache = self.__cache_pool__[key] = \
+                        {'__secondary_lock__': threading.Lock()}
 
-        return self.__cache_pool__[key]
+        try:
+            result: Any = cache['__return__']
+        except KeyError:
+            with cache['__secondary_lock__']:
+                if '__return__' in cache:
+                    result: Any = cache['__return__']
+                else:
+                    result = cache['__return__'] = self.__func__(*a, **kw)
+                    del cache['__secondary_lock__']
+
+        return result
+
+    async def acore(self, *a, **kw) -> WrappedReturn:
+        key = a, frozenset(kw.items())
+
+        try:
+            cache: Dict[str, Any] = self.__cache_pool__[key]
+        except KeyError:
+            with self.__primary_lock__:
+                if key in self.__cache_pool__:
+                    cache: Dict[str, Any] = self.__cache_pool__[key]
+                else:
+                    cache = self.__cache_pool__[key] = \
+                        {'__secondary_lock__': threading.Lock()}
+
+        try:
+            result: Any = cache['__return__']
+        except KeyError:
+            with cache['__secondary_lock__']:
+                if '__return__' in cache:
+                    result: Any = cache['__return__']
+                else:
+                    result = cache['__return__'] = await self.__func__(*a, **kw)
+                    del cache['__secondary_lock__']
+
+        return result
 
 
-class FunctionCallerExpires:
+class FunctionCallerTTL:
 
-    def __init__(
-            self,
-            duration: Union[int, float] = None,
-            expires:  Union[int, float] = None
-    ):
-        if duration is not None:
-            self.__duration = duration
-        elif expires is not None:
-            self.__duration = expires
-        else:
-            self.__duration = float('inf')
+    def __init__(self, ttl: Union[int, float, str] = float('inf')):
+        if isinstance(ttl, str):
+            ttl = time2second(ttl)
+        elif not isinstance(ttl, (int, float)):
+            raise TypeError(
+                'parameter "ttl" is expected to be of type int or float, '
+                f'not {ttl!r}.'
+            )
 
-        self.__exec_lock__  = threading.Lock()
-        self.__cache_pool__ = {}
+        self.__ttl = ttl
+        self.__primary_lock__ = threading.Lock()
+        self.__cache_pool__: FuncCachePool = {}
 
-    def __call__(self, func: FunctionType):
+    def __call__(self, func: Wrapped) -> WrappedClosure:
         self.__func__ = func
 
         if asyncio.iscoroutinefunction(getattr(func, '__wrapped__', func)):
-            self.__core__ = self.__core_async__
+            self.core = self.acore
 
         @functools.wraps(func, updated=('__dict__', '__globals__'))
-        def inner(*a, **kw):
-            return self.__core__(func, *a, **kw)
+        def inner(*a, **kw) -> Any:
+            return self.core(func, *a, **kw)
 
         inner.__cache_pool__ = self.__cache_pool__
 
         return inner
 
-    def __core__(self, func, *a, **kw):
-        key = a, str(kw)
+    def core(self, func: Wrapped, *a, **kw) -> WrappedReturn:
+        key = a, frozenset(kw.items())
+        cache: Dict[str, Any] = self.__cache_pool__.get(key)
 
-        if key not in self.__cache_pool__ or \
-                self.__cache_pool__[key]['__expiration_time__'] < time.time():
-            with self.__exec_lock__:
-                self.__cache_pool__[key] = {
-                    '__return__': func(*a, **kw),
-                    '__expiration_time__': time.time() + self.__duration
-                }
+        if not cache:
+            with self.__primary_lock__:
+                if key not in self.__cache_pool__:
+                    cache = self.__cache_pool__[key] = {
+                        '__secondary_lock__': threading.Lock(),
+                        '__expiration_time__': 0
+                    }
 
-        return self.__cache_pool__[key]['__return__']
+        if cache['__expiration_time__'] < time.monotonic():
+            with cache['__secondary_lock__']:
+                if cache['__expiration_time__'] < time.monotonic():
+                    cache['__return__'] = func(*a, **kw)
+                    cache['__expiration_time__'] = time.monotonic() + self.__ttl
 
-    async def __core_async__(self, func, *a, **kw):
-        key = a, str(kw)
+        return cache['__return__']
 
-        if key not in self.__cache_pool__ or \
-                self.__cache_pool__[key]['__expiration_time__'] < time.time():
-            with self.__exec_lock__:
-                self.__cache_pool__[key] = {
-                    '__return__': await func(*a, **kw),
-                    '__expiration_time__': time.time() + self.__duration
-                }
+    async def acore(self, func: Wrapped, *a, **kw) -> WrappedReturn:
+        key = a, frozenset(kw.items())
+        cache: Dict[str, Any] = self.__cache_pool__.get(key)
 
-        return self.__cache_pool__[key]['__return__']
+        if not cache:
+            with self.__primary_lock__:
+                if key not in self.__cache_pool__:
+                    cache = self.__cache_pool__[key] = {
+                        '__secondary_lock__': threading.Lock(),
+                        '__expiration_time__': 0
+                    }
+
+        if cache['__expiration_time__'] < time.monotonic():
+            with cache['__secondary_lock__']:
+                if cache['__expiration_time__'] < time.monotonic():
+                    cache['__return__'] = await func(*a, **kw)
+                    cache['__expiration_time__'] = time.monotonic() + self.__ttl
+
+        return cache['__return__']
 
 
-def __getattribute__(cls: FuncCache):
-    def inner(ins: cls, attr: str):
-        sget = super(cls, ins).__getattribute__
+class FunctionCallerCount:
+
+    def __init__(self, count: int = 0):
+        if count.__class__ is not int:
+            x: str = count.__class__.__name__
+            raise TypeError(
+                f'parameter "count" type must be an int, not "{x}".'
+            )
+        self.__count = count
+        self.__primary_lock__ = threading.Lock()
+        self.__cache_pool__: FuncCachePool = {}
+
+    def __call__(self, func: Wrapped) -> WrappedClosure:
+        self.__func__ = func
+
+        if asyncio.iscoroutinefunction(getattr(func, '__wrapped__', func)):
+            self.core = self.acore
+
+        @functools.wraps(func, updated=('__dict__', '__globals__'))
+        def inner(*a, **kw) -> Any:
+            return self.core(func, *a, **kw)
+
+        inner.__cache_pool__ = self.__cache_pool__
+
+        return inner
+
+    def core(self, func: Wrapped, *a, **kw) -> WrappedReturn:
+        key = a, frozenset(kw.items())
+        cache: Dict[str, Any] = self.__cache_pool__.get(key)
+
+        if not cache:
+            with self.__primary_lock__:
+                if key not in self.__cache_pool__:
+                    cache = self.__cache_pool__[key] = {
+                        '__secondary_lock__': threading.Lock(),
+                        '__count__': self.__count
+                    }
+
+        if cache['__count__'] == self.__count:
+            with cache['__secondary_lock__']:
+                if cache['__count__'] == self.__count:
+                    cache['__return__'] = func(*a, **kw)
+                    cache['__count__'] = 1
+        else:
+            cache['__count__'] += 1
+
+        return cache['__return__']
+
+    async def acore(self, func: Wrapped, *a, **kw) -> WrappedReturn:
+        key = a, frozenset(kw.items())
+        cache: Dict[str, Any] = self.__cache_pool__.get(key)
+
+        if not cache:
+            with self.__primary_lock__:
+                if key not in self.__cache_pool__:
+                    cache = self.__cache_pool__[key] = {
+                        '__secondary_lock__': threading.Lock(),
+                        '__count__': self.__count
+                    }
+
+        if cache['__count__'] == self.__count:
+            with cache['__secondary_lock__']:
+                if cache['__count__'] == self.__count:
+                    cache['__return__'] = await func(*a, **kw)
+                    cache['__count__'] = 1
+        else:
+            cache['__count__'] += 1
+
+        return cache['__return__']
+
+
+def __getattribute__(cls: FuncCache) -> Callable:
+    def inner(ins: cls, attr: str) -> Any:
+        sget: Callable[[str], Any] = super(cls, ins).__getattribute__
 
         if (
                 attr in ('__cache_pool__', '__not_cache__') or
@@ -312,7 +466,7 @@ def __getattribute__(cls: FuncCache):
         ):
             return sget(attr)
 
-        value = getattr(cls, attr)
+        value: Any = getattr(cls, attr)
 
         if not (callable(value) or value.__class__ in (property, classmethod)):
             return sget(attr)
@@ -322,10 +476,36 @@ def __getattribute__(cls: FuncCache):
     return inner
 
 
-def clear_cache_pool(func) -> None:
+def clear_cache_pool(
+        func: Union[FunctionCaller, FunctionCallerTTL, Type[object], FuncCache]
+) -> None:
     try:
         func.__cache_pool__.clear()
     except AttributeError:
         raise TypeError(
             f'"{func.__module__}.{func.__qualname__}" is not cached.'
         ) from None
+
+
+def time2second(unit_time: str, *, __pattern__=re.compile(r'''
+        (?:(\d+(?:\.\d+)?)d)?
+        (?:(\d+(?:\.\d+)?)h)?
+        (?:(\d+(?:\.\d+)?)m)?
+        (?:(\d+(?:\.\d+)?)s?)?
+''', flags=re.X | re.I)) -> Union[int, float]:
+    if unit_time.isdigit():
+        return int(unit_time)
+
+    match = __pattern__.fullmatch(unit_time)
+
+    if not (unit_time and match):
+        raise ValueError(f'unit time {unit_time!r} format is incorrect.')
+
+    r = 0
+
+    for x, s in zip(match.groups(), (86400, 3600, 60, 1)):
+        if x is not None:
+            x = int(x) if x.isdigit() else float(x)
+            r += x * s
+
+    return int(r) if isinstance(r, float) and r.is_integer() else r

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,14 @@ setuptools.setup(
     license='Apache 2.0',
     url='http://gqylpy.com',
     project_urls={'Source': source},
-    description='如其名，它实现缓存功能，可缓存某个函数或某个类中定义的所有方法的返回值。',
+    description='''
+        True to its name, `funccache` implements the cache function. Cache the
+        return value of a callable object or all methods defined in a class.
+    '''.strip().replace('\n       ', ''),
     long_description=open('README.md', encoding='utf8').read(),
     long_description_content_type='text/markdown',
     packages=[i.__name__],
-    python_requires='>=3.6, <4',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -38,6 +41,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12'
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13'
     ]
 )


### PR DESCRIPTION
1. The scheme of reconstructing the return value of the cache function, uses the secondary lock. Solve the lock contention problem when the function is called concurrently with different parameters.
2. The return value of the method in the cache class supports setting the expiration time.
3. Add a decorator named `count`, supports caching the return value of a function by number of calls.
4. The decorator with cache expiration `expires` is renamed to `ttl`.
5. The cache expiration time parameter can be passed in unit-time (such as "1h40m").
6. Fix issue: When an exception occurs in the call to the cached object, subsequent successive calls always raise `KeyError: '__return__'`. #2
7. Fix issue: Concurrent calls when the return value of the function has not been cached or has expired may repeat the execution of the function. #4
8. The `__getattribute__` method is no longer silently overridden, and an exception is thrown directly if it exists.
9. Internal code adds type annotations, as well as a lot of optimization and refactoring.
10. Refactor the internal method `Time2Second` to make it more concise and efficient.
11. Use `time.monotonic()` to replace `time.time()` for cache expiration checks.
12. Fix the potential errors that may occur in the class cache when running in performance mode.
---
1. 重构缓存函数返回值的方案，现采用二级锁。解决以不同参数并发调用函数时的锁竞争问题。
2. 缓存类中方法的返回值支持设置过期时间。
3. 新增装饰器 `count`，支持按调用次数缓存函数的返回值。
4. 带缓存有效期的装饰器 `expires` 更名为 `ttl`。
5. 缓存过期时间的参数支持按单位时间（如 "1h40m"）的方式传入。
6. 修复问题：当被缓存的对象调用出现异常后，后续的连续调用始终引发 `KeyError: '__return__'`。#2
7. 修复问题：当函数返回值还未被缓存或已过期时的并发调用可能重复执行函数。#4
8. 不再静默覆盖 `__getattribute__` 方法，如果它存在，将直接抛出异常。
9. 内部代码添加类型注解，以及大量优化和重构。
10. 重构内部方法 `Time2Second` 使之更简洁和高效。
11. 使用 `time.monotonic()` 替换 `time.time()` 进行缓存过期检查。
12. 修复在性能模式下运行时类缓存器可能发生的错误。
